### PR TITLE
Fix missing props propagation for Square in Blog

### DIFF
--- a/src/components/Blog/Blog.js
+++ b/src/components/Blog/Blog.js
@@ -67,7 +67,7 @@ class Blog extends Component {
       <Wrapper>
         <StyledText {...rest} height={titleHeight} width={titleWidth} />
         <ImageWrapper>
-          <Square length={128} />
+          <Square {...rest} length={128} />
         </ImageWrapper>
         <Article>
           <Paragraph {...rest} height={height} row={row} />


### PR DESCRIPTION
This PR address the missing propagation of props to the Square component inside Blog component that was visible in style guide of this project